### PR TITLE
18 - Modify PHY structs to use unconstrained types

### DIFF
--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -98,7 +98,7 @@ namespace PhyParser {
     std::vector<uint16_t> indices;
     indices.reserve(ledge.trianglesCount * 3);
 
-    unsigned int maxVertexIndex = 0;
+    uint32_t maxVertexIndex = 0;
     for (const auto& triangle : triangles) {
       const auto index1 = triangle.edges[0].startPointIndex;
       const auto index2 = triangle.edges[1].startPointIndex;

--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -98,7 +98,7 @@ namespace PhyParser {
     std::vector<uint16_t> indices;
     indices.reserve(ledge.trianglesCount * 3);
 
-    uint16_t maxVertexIndex = 0;
+    unsigned int maxVertexIndex = 0;
     for (const auto& triangle : triangles) {
       const auto index1 = triangle.edges[0].startPointIndex;
       const auto index2 = triangle.edges[1].startPointIndex;

--- a/src/structs/phy.hpp
+++ b/src/structs/phy.hpp
@@ -33,8 +33,8 @@ namespace PhyParser::Structs {
     Vector3 massCentre;
     Vector3 rotationInertia;
     float upperLimitRadius;
-    int maxDeviation : 8;
-    int byteSize : 24;
+    uint32_t maxDeviation : 8;
+    uint32_t byteSize : 24;
     int32_t offsetLedgetreeRoot;
     std::array<int32_t, 2> unused;
     std::array<char, 4> id; // Should be IVPS
@@ -57,26 +57,26 @@ namespace PhyParser::Structs {
     int32_t pointOffset;
     int32_t boneIndex;
 
-    unsigned int hasChildrenFlags : 2;
-    int isCompactFlag : 2;
-    unsigned int dummy : 4;
-    unsigned int sizeDiv16 : 24;
+    uint32_t hasChildrenFlags : 2;
+    uint32_t isCompactFlag : 2;
+    uint32_t dummy : 4;
+    uint32_t sizeDiv16 : 24;
 
     uint16_t trianglesCount;
     int16_t unknown;
   };
 
   struct Edge {
-    unsigned int startPointIndex : 16;
-    unsigned int oppositePointIndex : 15;
-    unsigned int isVirtual : 1;
+    uint32_t startPointIndex : 16;
+    uint32_t oppositePointIndex : 15;
+    uint32_t isVirtual : 1;
   };
 
   struct CompactTriangle {
-    unsigned int triangleIndex : 12;
-    unsigned int pierceIndex : 12;
-    unsigned int materialIndex : 7;
-    unsigned int isVirtual : 1;
+    uint32_t triangleIndex : 12;
+    uint32_t pierceIndex : 12;
+    uint32_t materialIndex : 7;
+    uint32_t isVirtual : 1;
 
     std::array<Edge, 3> edges;
   };

--- a/src/structs/phy.hpp
+++ b/src/structs/phy.hpp
@@ -33,8 +33,8 @@ namespace PhyParser::Structs {
     Vector3 massCentre;
     Vector3 rotationInertia;
     float upperLimitRadius;
-    int32_t maxDeviation : 8;
-    int32_t byteSize : 24;
+    int maxDeviation : 8;
+    int byteSize : 24;
     int32_t offsetLedgetreeRoot;
     std::array<int32_t, 2> unused;
     std::array<char, 4> id; // Should be IVPS
@@ -57,26 +57,26 @@ namespace PhyParser::Structs {
     int32_t pointOffset;
     int32_t boneIndex;
 
-    uint32_t hasChildrenFlags : 2;
-    int32_t isCompactFlag : 2;
-    uint32_t dummy : 4;
-    uint32_t sizeDiv16 : 24;
+    unsigned int hasChildrenFlags : 2;
+    int isCompactFlag : 2;
+    unsigned int dummy : 4;
+    unsigned int sizeDiv16 : 24;
 
     uint16_t trianglesCount;
     int16_t unknown;
   };
 
   struct Edge {
-    uint16_t startPointIndex : 16;
-    uint16_t oppositePointIndex : 15;
-    uint16_t isVirtual : 1;
+    unsigned int startPointIndex : 16;
+    unsigned int oppositePointIndex : 15;
+    unsigned int isVirtual : 1;
   };
 
   struct CompactTriangle {
-    uint16_t triangleIndex : 12;
-    uint16_t pierceIndex : 12;
-    uint16_t materialIndex : 7;
-    uint16_t isVirtual : 1;
+    unsigned int triangleIndex : 12;
+    unsigned int pierceIndex : 12;
+    unsigned int materialIndex : 7;
+    unsigned int isVirtual : 1;
 
     std::array<Edge, 3> edges;
   };


### PR DESCRIPTION
Changes are in the title, there's not much to add.

This adds Windows support. It's also a blocker for issue #18 in the TASBox repo.