### PR TITLE
NONE - Fix ledgetree traversal and add editor configs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,45 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+# Based on https://gist.github.com/nicklasfrahm/4a4fff24381f85ada76ccb651f555e1f?permalink_comment_id=4981874#gistcomment-4981874
+
+ColumnLimit: 120
+ContinuationIndentWidth: 2
+IndentWidth: 2
+TabWidth: 2
+ConstructorInitializerIndentWidth: 2
+IndentCaseLabels: true
+PenaltyReturnTypeOnItsOwnLine: 20000
+PenaltyIndentedWhitespace: 0
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakBeforeFirstCallParameter: 0
+UseTab: Never
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: DontAlign
+AlignAfterOpenBracket: BlockIndent
+AlignOperands: false
+AlignTrailingComments: false
+BinPackArguments: false
+BinPackParameters: false
+SpacesInContainerLiterals: false
+Cpp11BracedListStyle: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Always
+FixNamespaceComments: false
+ReflowComments: false
+NamespaceIndentation: All
+IncludeBlocks: Merge
+BreakStringLiterals: false
+BreakConstructorInitializers: AfterColon
+IndentPPDirectives: BeforeHash
+IncludeCategories:
+    -   Regex: '"[[:alnum:]._-]+"'
+        Priority: 1
+        SortPriority: 1
+    -   Regex: '^((<|").*/)'
+        Priority: 2
+        SortPriority: 2
+    -   Regex: "<[[:alnum:]._-]+>"
+        Priority: 3
+        SortPriority: 3
+PointerAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks: "*,
+        -abseil-*,
+        -altera-*,
+        -android-*,
+        -fuchsia-*,
+        -google-*,
+        -llvm*,
+        -modernize-use-trailing-return-type,
+        -zircon-*,
+        -readability-else-after-return,
+        -readability-static-accessed-through-instance,
+        -readability-avoid-const-params-in-decls,
+        -cppcoreguidelines-non-private-member-variables-in-classes,
+        -misc-non-private-member-variables-in-classes,
+        -*-uppercase-literal-suffix,
+        -misc-include-cleaner,
+        -*-reinterpret-cast,
+        -*-magic-numbers,
+        -*-identifier-length,
+        -*-pro-type-union-access,
+        -*-vararg,
+        -*-avoid-do-while
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+
+[{*.json,.babelrc,.eslintrc,.prettierrc,jest.config,*.yaml,*.yml}]
+indent_size = 2
+indent_style = space

--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -1,123 +1,144 @@
 #include "phy.hpp"
-#include "helpers/offset-data-view.hpp"
+
 #include <algorithm>
 #include <stack>
 
+#include "helpers/offset-data-view.hpp"
+
 namespace PhyParser {
-  using namespace Errors;
-  using namespace Enums;
-  using namespace Structs;
+using namespace Errors;
+using namespace Enums;
+using namespace Structs;
 
-  Phy::Phy(const std::span<std::byte>& data, const std::optional<int64_t>& checksum) {
-    const OffsetDataView dataView(data);
-    header = dataView.parseStruct<Header>(0, "Failed to parse PHY header").first;
+Phy::Phy(
+	const std::span<std::byte> &data, const std::optional<int64_t> &checksum
+) {
+	const OffsetDataView dataView(data);
+	header =
+		dataView.parseStruct<Header>(0, "Failed to parse PHY header").first;
 
-    if (checksum.has_value() && header.checksum != checksum.value()) {
-      throw InvalidChecksum("PHY checksum does not match");
-    }
+	if (checksum.has_value() && header.checksum != checksum.value()) {
+		throw InvalidChecksum("PHY checksum does not match");
+	}
 
-    solids.reserve(header.solidCount);
-    size_t offset = header.size;
-    for (int i = 0; i < header.solidCount; i++) {
-      const auto surfaceHeader = dataView.parseStruct<SurfaceHeader>(offset, "Failed to parse surface header").first;
+	solids.reserve(header.solidCount);
+	size_t offset = header.size;
+	for (int i = 0; i < header.solidCount; i++) {
+		const auto surfaceHeader =
+			dataView
+				.parseStruct<SurfaceHeader>(
+					offset, "Failed to parse surface header"
+				)
+				.first;
 
-      auto solidsForSurface = parseSurface(surfaceHeader, dataView.withOffset(offset + sizeof(SurfaceHeader)));
-      solids.insert(
-        solids.end(), std::make_move_iterator(solidsForSurface.begin()), std::make_move_iterator(solidsForSurface.end())
-      );
+		auto solidsForSurface = parseSurface(
+			surfaceHeader, dataView.withOffset(offset + sizeof(SurfaceHeader))
+		);
+		solids.insert(
+			solids.end(),
+			std::make_move_iterator(solidsForSurface.begin()),
+			std::make_move_iterator(solidsForSurface.end())
+		);
 
-      offset += surfaceHeader.size + sizeof(SurfaceHeader::size);
-    }
+		offset += surfaceHeader.size + sizeof(SurfaceHeader::size);
+	}
 
-    const auto rawTextSection = dataView.parseString(offset, "Failed to parse text section");
-    textSection = parseTextSection(rawTextSection);
-  }
-
-  int64_t Phy::getChecksum() const {
-    return header.checksum;
-  }
-
-  const std::vector<Phy::Solid>& Phy::getSolids() const {
-    return solids;
-  }
-  const TextSection& Phy::getTextSection() const {
-    return textSection;
-  }
-
-  std::vector<Phy::Solid> Phy::parseSurface(const SurfaceHeader& surfaceHeader, const OffsetDataView& data) {
-    switch (surfaceHeader.modelType) {
-      case ModelType::IVPCompactSurface:
-        return parseCompactSurface(data);
-      case ModelType::IVPMOPP:
-        return parseMopp(data);
-      case ModelType::IVPBall:
-        throw InvalidBody("Unsupported surface model type IVPBall");
-      case ModelType::IVPVirtual:
-        throw InvalidBody("Unsupported surface model type IVPVirtual");
-      default:
-        throw InvalidBody("Unrecognised surface model type");
-    }
-  }
-
-  std::vector<Phy::Solid> Phy::parseCompactSurface(const OffsetDataView& data) {
-    const auto [surfaceHeader, headerOffset] =
-      data.parseStruct<CompactSurfaceHeader>(0, "Failed to parse compact surface header");
-    const auto nodeData =
-      data.withOffset(headerOffset + offsetof(CompactSurfaceHeader, massCentre) + surfaceHeader.offsetLedgetreeRoot);
-
-    std::vector<Solid> solids;
-    std::stack<size_t> nodeOffsets;
-    nodeOffsets.push(0);
-
-    while (!nodeOffsets.empty()) {
-      auto [node, nodeOffset] = nodeData.parseStruct<LedgeNode>(nodeOffsets.top(), "Failed to parse ledge node");
-      nodeOffsets.pop();
-
-      if (node.isTerminal()) {
-        const auto [ledge, ledgeOffset] = nodeData.parseStruct<Ledge>(node.compactNodeOffset, "Failed to parse ledge");
-
-        solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
-      } else {
-        nodeOffsets.push(nodeOffset + node.rightNodeOffset);
-        nodeOffsets.push(nodeOffset + sizeof(LedgeNode));
-      }
-    }
-
-    return std::move(solids);
-  }
-
-  std::vector<Phy::Solid> Phy::parseMopp(const OffsetDataView& /*data*/) {
-    throw std::runtime_error("Not implemented");
-  }
-
-  Phy::Solid Phy::parseLedge(const Ledge& ledge, const OffsetDataView& data) {
-    const auto triangles = data.parseStructArrayWithoutOffsets<CompactTriangle>(
-      sizeof(Ledge), ledge.trianglesCount, "Failed to parse triangle array"
-    );
-
-    std::vector<uint16_t> indices;
-    indices.reserve(ledge.trianglesCount * 3);
-
-    uint32_t maxVertexIndex = 0;
-    for (const auto& triangle : triangles) {
-      const auto index1 = triangle.edges[0].startPointIndex;
-      const auto index2 = triangle.edges[1].startPointIndex;
-      const auto index3 = triangle.edges[2].startPointIndex;
-
-      maxVertexIndex = std::max({maxVertexIndex, index1, index2, index3});
-      indices.push_back(index1);
-      indices.push_back(index2);
-      indices.push_back(index3);
-    }
-
-    auto vertices = data.parseStructArrayWithoutOffsets<Vector4>(
-      ledge.pointOffset, maxVertexIndex + 1, "Failed to parse vertex array"
-    );
-
-    return {
-      .vertices = std::move(vertices),
-      .indices = std::move(indices),
-      .boneIndex = ledge.boneIndex,
-    };
-  }
+	const auto rawTextSection =
+		dataView.parseString(offset, "Failed to parse text section");
+	textSection = parseTextSection(rawTextSection);
 }
+
+int64_t Phy::getChecksum() const { return header.checksum; }
+
+const std::vector<Phy::Solid> &Phy::getSolids() const { return solids; }
+const TextSection &Phy::getTextSection() const { return textSection; }
+
+std::vector<Phy::Solid> Phy::parseSurface(
+	const SurfaceHeader &surfaceHeader, const OffsetDataView &data
+) {
+	switch (surfaceHeader.modelType) {
+		case ModelType::IVPCompactSurface:
+			return parseCompactSurface(data);
+		case ModelType::IVPMOPP:
+			return parseMopp(data);
+		case ModelType::IVPBall:
+			throw InvalidBody("Unsupported surface model type IVPBall");
+		case ModelType::IVPVirtual:
+			throw InvalidBody("Unsupported surface model type IVPVirtual");
+		default:
+			throw InvalidBody("Unrecognised surface model type");
+	}
+}
+
+std::vector<Phy::Solid> Phy::parseCompactSurface(const OffsetDataView &data) {
+	const auto [surfaceHeader, headerOffset] =
+		data.parseStruct<CompactSurfaceHeader>(
+			0, "Failed to parse compact surface header"
+		);
+	const auto ledgetreeRoot = headerOffset +
+							   offsetof(CompactSurfaceHeader, massCentre) +
+							   surfaceHeader.offsetLedgetreeRoot;
+
+	const auto nodeData = data.withOffset(ledgetreeRoot);
+
+	std::vector<Solid> solids;
+	std::stack<size_t> nodeOffsets;
+	nodeOffsets.push(0);
+
+	while (!nodeOffsets.empty()) {
+		auto [node, nodeOffset] = nodeData.parseStruct<LedgeNode>(
+			nodeOffsets.top(), "Failed to parse ledge node"
+		);
+		nodeOffsets.pop();
+
+		if (node.isTerminal()) {
+			const auto [ledge, ledgeOffset] = nodeData.parseStruct<Ledge>(
+				nodeOffset + node.compactNodeOffset - ledgetreeRoot,
+				"Failed to parse ledge"
+			);
+
+			solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
+		} else {
+			nodeOffsets.push(nodeOffset + node.rightNodeOffset - ledgetreeRoot);
+			nodeOffsets.push(nodeOffset + sizeof(LedgeNode) - ledgetreeRoot);
+		}
+	}
+
+	return std::move(solids);
+}
+
+std::vector<Phy::Solid> Phy::parseMopp(const OffsetDataView & /*data*/) {
+	throw std::runtime_error("Not implemented");
+}
+
+Phy::Solid Phy::parseLedge(const Ledge &ledge, const OffsetDataView &data) {
+	const auto triangles = data.parseStructArrayWithoutOffsets<CompactTriangle>(
+		sizeof(Ledge), ledge.trianglesCount, "Failed to parse triangle array"
+	);
+
+	std::vector<uint16_t> indices;
+	indices.reserve(ledge.trianglesCount * 3);
+
+	uint32_t maxVertexIndex = 0;
+	for (const auto &triangle : triangles) {
+		const auto index1 = triangle.edges[0].startPointIndex;
+		const auto index2 = triangle.edges[1].startPointIndex;
+		const auto index3 = triangle.edges[2].startPointIndex;
+
+		maxVertexIndex = std::max({maxVertexIndex, index1, index2, index3});
+		indices.push_back(index1);
+		indices.push_back(index2);
+		indices.push_back(index3);
+	}
+
+	auto vertices = data.parseStructArrayWithoutOffsets<Vector4>(
+		ledge.pointOffset, maxVertexIndex + 1, "Failed to parse vertex array"
+	);
+
+	return {
+		.vertices = std::move(vertices),
+		.indices = std::move(indices),
+		.boneIndex = ledge.boneIndex,
+	};
+}
+}  // namespace PhyParser

--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -1,144 +1,126 @@
 #include "phy.hpp"
-
+#include "helpers/offset-data-view.hpp"
 #include <algorithm>
 #include <stack>
 
-#include "helpers/offset-data-view.hpp"
-
 namespace PhyParser {
-using namespace Errors;
-using namespace Enums;
-using namespace Structs;
+  using namespace Errors;
+  using namespace Enums;
+  using namespace Structs;
 
-Phy::Phy(
-	const std::span<std::byte> &data, const std::optional<int64_t> &checksum
-) {
-	const OffsetDataView dataView(data);
-	header =
-		dataView.parseStruct<Header>(0, "Failed to parse PHY header").first;
+  Phy::Phy(const std::span<std::byte>& data, const std::optional<int64_t>& checksum) {
+    const OffsetDataView dataView(data);
+    header = dataView.parseStruct<Header>(0, "Failed to parse PHY header").first;
 
-	if (checksum.has_value() && header.checksum != checksum.value()) {
-		throw InvalidChecksum("PHY checksum does not match");
-	}
+    if (checksum.has_value() && header.checksum != checksum.value()) {
+      throw InvalidChecksum("PHY checksum does not match");
+    }
 
-	solids.reserve(header.solidCount);
-	size_t offset = header.size;
-	for (int i = 0; i < header.solidCount; i++) {
-		const auto surfaceHeader =
-			dataView
-				.parseStruct<SurfaceHeader>(
-					offset, "Failed to parse surface header"
-				)
-				.first;
+    solids.reserve(header.solidCount);
+    size_t offset = header.size;
+    for (int i = 0; i < header.solidCount; i++) {
+      const auto surfaceHeader = dataView.parseStruct<SurfaceHeader>(offset, "Failed to parse surface header").first;
 
-		auto solidsForSurface = parseSurface(
-			surfaceHeader, dataView.withOffset(offset + sizeof(SurfaceHeader))
-		);
-		solids.insert(
-			solids.end(),
-			std::make_move_iterator(solidsForSurface.begin()),
-			std::make_move_iterator(solidsForSurface.end())
-		);
+      auto solidsForSurface = parseSurface(surfaceHeader, dataView.withOffset(offset + sizeof(SurfaceHeader)));
+      solids.insert(
+        solids.end(), std::make_move_iterator(solidsForSurface.begin()), std::make_move_iterator(solidsForSurface.end())
+      );
 
-		offset += surfaceHeader.size + sizeof(SurfaceHeader::size);
-	}
+      offset += surfaceHeader.size + sizeof(SurfaceHeader::size);
+    }
 
-	const auto rawTextSection =
-		dataView.parseString(offset, "Failed to parse text section");
-	textSection = parseTextSection(rawTextSection);
-}
+    const auto rawTextSection = dataView.parseString(offset, "Failed to parse text section");
+    textSection = parseTextSection(rawTextSection);
+  }
 
-int64_t Phy::getChecksum() const { return header.checksum; }
+  int64_t Phy::getChecksum() const {
+    return header.checksum;
+  }
 
-const std::vector<Phy::Solid> &Phy::getSolids() const { return solids; }
-const TextSection &Phy::getTextSection() const { return textSection; }
+  const std::vector<Phy::Solid>& Phy::getSolids() const {
+    return solids;
+  }
+  const TextSection& Phy::getTextSection() const {
+    return textSection;
+  }
 
-std::vector<Phy::Solid> Phy::parseSurface(
-	const SurfaceHeader &surfaceHeader, const OffsetDataView &data
-) {
-	switch (surfaceHeader.modelType) {
-		case ModelType::IVPCompactSurface:
-			return parseCompactSurface(data);
-		case ModelType::IVPMOPP:
-			return parseMopp(data);
-		case ModelType::IVPBall:
-			throw InvalidBody("Unsupported surface model type IVPBall");
-		case ModelType::IVPVirtual:
-			throw InvalidBody("Unsupported surface model type IVPVirtual");
-		default:
-			throw InvalidBody("Unrecognised surface model type");
-	}
-}
+  std::vector<Phy::Solid> Phy::parseSurface(const SurfaceHeader& surfaceHeader, const OffsetDataView& data) {
+    switch (surfaceHeader.modelType) {
+      case ModelType::IVPCompactSurface:
+        return parseCompactSurface(data);
+      case ModelType::IVPMOPP:
+        return parseMopp(data);
+      case ModelType::IVPBall:
+        throw InvalidBody("Unsupported surface model type IVPBall");
+      case ModelType::IVPVirtual:
+        throw InvalidBody("Unsupported surface model type IVPVirtual");
+      default:
+        throw InvalidBody("Unrecognised surface model type");
+    }
+  }
 
-std::vector<Phy::Solid> Phy::parseCompactSurface(const OffsetDataView &data) {
-	const auto [surfaceHeader, headerOffset] =
-		data.parseStruct<CompactSurfaceHeader>(
-			0, "Failed to parse compact surface header"
-		);
-	const auto ledgetreeRoot = headerOffset +
-							   offsetof(CompactSurfaceHeader, massCentre) +
-							   surfaceHeader.offsetLedgetreeRoot;
+  std::vector<Phy::Solid> Phy::parseCompactSurface(const OffsetDataView& data) {
+    const auto [surfaceHeader, headerOffset] =
+      data.parseStruct<CompactSurfaceHeader>(0, "Failed to parse compact surface header");
+    const auto ledgetreeRoot =
+      headerOffset + offsetof(CompactSurfaceHeader, massCentre) + surfaceHeader.offsetLedgetreeRoot;
 
-	const auto nodeData = data.withOffset(ledgetreeRoot);
+    const auto nodeData = data.withOffset(ledgetreeRoot);
 
-	std::vector<Solid> solids;
-	std::stack<size_t> nodeOffsets;
-	nodeOffsets.push(0);
+    std::vector<Solid> solids;
+    std::stack<size_t> nodeOffsets;
+    nodeOffsets.push(0);
 
-	while (!nodeOffsets.empty()) {
-		auto [node, nodeOffset] = nodeData.parseStruct<LedgeNode>(
-			nodeOffsets.top(), "Failed to parse ledge node"
-		);
-		nodeOffsets.pop();
+    while (!nodeOffsets.empty()) {
+      auto [node, nodeOffset] = nodeData.parseStruct<LedgeNode>(nodeOffsets.top(), "Failed to parse ledge node");
+      nodeOffsets.pop();
 
-		if (node.isTerminal()) {
-			const auto [ledge, ledgeOffset] = nodeData.parseStruct<Ledge>(
-				nodeOffset + node.compactNodeOffset - ledgetreeRoot,
-				"Failed to parse ledge"
-			);
+      if (node.isTerminal()) {
+        const auto [ledge, ledgeOffset] =
+          nodeData.parseStruct<Ledge>(nodeOffset + node.compactNodeOffset - ledgetreeRoot, "Failed to parse ledge");
 
-			solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
-		} else {
-			nodeOffsets.push(nodeOffset + node.rightNodeOffset - ledgetreeRoot);
-			nodeOffsets.push(nodeOffset + sizeof(LedgeNode) - ledgetreeRoot);
-		}
-	}
+        solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
+      } else {
+        nodeOffsets.push(nodeOffset + node.rightNodeOffset - ledgetreeRoot);
+        nodeOffsets.push(nodeOffset + sizeof(LedgeNode) - ledgetreeRoot);
+      }
+    }
 
-	return std::move(solids);
-}
+    return std::move(solids);
+  }
 
-std::vector<Phy::Solid> Phy::parseMopp(const OffsetDataView & /*data*/) {
-	throw std::runtime_error("Not implemented");
-}
+  std::vector<Phy::Solid> Phy::parseMopp(const OffsetDataView& /*data*/) {
+    throw std::runtime_error("Not implemented");
+  }
 
-Phy::Solid Phy::parseLedge(const Ledge &ledge, const OffsetDataView &data) {
-	const auto triangles = data.parseStructArrayWithoutOffsets<CompactTriangle>(
-		sizeof(Ledge), ledge.trianglesCount, "Failed to parse triangle array"
-	);
+  Phy::Solid Phy::parseLedge(const Ledge& ledge, const OffsetDataView& data) {
+    const auto triangles = data.parseStructArrayWithoutOffsets<CompactTriangle>(
+      sizeof(Ledge), ledge.trianglesCount, "Failed to parse triangle array"
+    );
 
-	std::vector<uint16_t> indices;
-	indices.reserve(ledge.trianglesCount * 3);
+    std::vector<uint16_t> indices;
+    indices.reserve(ledge.trianglesCount * 3);
 
-	uint32_t maxVertexIndex = 0;
-	for (const auto &triangle : triangles) {
-		const auto index1 = triangle.edges[0].startPointIndex;
-		const auto index2 = triangle.edges[1].startPointIndex;
-		const auto index3 = triangle.edges[2].startPointIndex;
+    uint32_t maxVertexIndex = 0;
+    for (const auto& triangle : triangles) {
+      const auto index1 = triangle.edges[0].startPointIndex;
+      const auto index2 = triangle.edges[1].startPointIndex;
+      const auto index3 = triangle.edges[2].startPointIndex;
 
-		maxVertexIndex = std::max({maxVertexIndex, index1, index2, index3});
-		indices.push_back(index1);
-		indices.push_back(index2);
-		indices.push_back(index3);
-	}
+      maxVertexIndex = std::max({maxVertexIndex, index1, index2, index3});
+      indices.push_back(index1);
+      indices.push_back(index2);
+      indices.push_back(index3);
+    }
 
-	auto vertices = data.parseStructArrayWithoutOffsets<Vector4>(
-		ledge.pointOffset, maxVertexIndex + 1, "Failed to parse vertex array"
-	);
+    auto vertices = data.parseStructArrayWithoutOffsets<Vector4>(
+      ledge.pointOffset, maxVertexIndex + 1, "Failed to parse vertex array"
+    );
 
-	return {
-		.vertices = std::move(vertices),
-		.indices = std::move(indices),
-		.boneIndex = ledge.boneIndex,
-	};
-}
-}  // namespace PhyParser
+    return {
+      .vertices = std::move(vertices),
+      .indices = std::move(indices),
+      .boneIndex = ledge.boneIndex,
+    };
+  }
+} // namespace PhyParser

--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -62,14 +62,14 @@ namespace PhyParser {
   std::vector<Phy::Solid> Phy::parseCompactSurface(const OffsetDataView& data) {
     const auto [surfaceHeader, headerOffset] =
       data.parseStruct<CompactSurfaceHeader>(0, "Failed to parse compact surface header");
-    const auto ledgetreeRoot =
-      headerOffset + offsetof(CompactSurfaceHeader, massCentre) + surfaceHeader.offsetLedgetreeRoot;
 
-    const auto nodeData = data.withOffset(ledgetreeRoot);
+    const auto rootNode = headerOffset + offsetof(CompactSurfaceHeader, massCentre) + surfaceHeader.offsetLedgetreeRoot;
+
+    const auto nodeData = data.withOffset(0);
 
     std::vector<Solid> solids;
     std::stack<size_t> nodeOffsets;
-    nodeOffsets.push(0);
+    nodeOffsets.push(rootNode);
 
     while (!nodeOffsets.empty()) {
       auto [node, nodeOffset] = nodeData.parseStruct<LedgeNode>(nodeOffsets.top(), "Failed to parse ledge node");
@@ -77,12 +77,12 @@ namespace PhyParser {
 
       if (node.isTerminal()) {
         const auto [ledge, ledgeOffset] =
-          nodeData.parseStruct<Ledge>(nodeOffset + node.compactNodeOffset - ledgetreeRoot, "Failed to parse ledge");
+          nodeData.parseStruct<Ledge>(nodeOffset + node.compactNodeOffset, "Failed to parse ledge");
 
         solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
       } else {
-        nodeOffsets.push(nodeOffset + node.rightNodeOffset - ledgetreeRoot);
-        nodeOffsets.push(nodeOffset + sizeof(LedgeNode) - ledgetreeRoot);
+        nodeOffsets.push(nodeOffset + node.rightNodeOffset);
+        nodeOffsets.push(nodeOffset + sizeof(LedgeNode));
       }
     }
 

--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -123,4 +123,4 @@ namespace PhyParser {
       .boneIndex = ledge.boneIndex,
     };
   }
-} // namespace PhyParser
+}


### PR DESCRIPTION
## Changes

- Adds editor configs from TASBox to this submodule to reduce friction between projects
- Converts each node offset to be relative to the ledge tree in the file
    - Previously, it would assume the offsets encoded in each node to be local to the ledge tree's root, which is wrong, they are local to the node itself with respect to the entire file.
    