### PR TITLE
NONE - Expose the center of mass in the PHY format to users

### DIFF
--- a/src/phy.cpp
+++ b/src/phy.cpp
@@ -80,7 +80,7 @@ namespace PhyParser {
         const auto [ledge, ledgeOffset] =
           nodeData.parseStruct<Ledge>(nodeOffset + node.compactNodeOffset, "Failed to parse ledge");
 
-        solids.push_back(parseLedge(ledge, data.withOffset(ledgeOffset)));
+        solids.push_back(parseLedge(ledge, surfaceHeader.massCentre, data.withOffset(ledgeOffset)));
       } else {
         nodeOffsets.push(nodeOffset + node.rightNodeOffset);
         nodeOffsets.push(nodeOffset + sizeof(LedgeNode));
@@ -94,7 +94,7 @@ namespace PhyParser {
     throw std::runtime_error("Not implemented");
   }
 
-  Phy::Solid Phy::parseLedge(const Ledge& ledge, const OffsetDataView& data) {
+  Phy::Solid Phy::parseLedge(const Ledge& ledge, const Structs::Vector3& centerOfMass, const OffsetDataView& data) {
     const auto triangles = data.parseStructArrayWithoutOffsets<CompactTriangle>(
       sizeof(Ledge), ledge.trianglesCount, "Failed to parse triangle array"
     );
@@ -123,6 +123,7 @@ namespace PhyParser {
     return {
       .vertices = std::move(vertices),
       .indices = std::move(indices),
+      .centerOfMass = centerOfMass,
       .boneIndex = ledge.boneIndex,
     };
   }

--- a/src/phy.hpp
+++ b/src/phy.hpp
@@ -15,7 +15,7 @@ namespace PhyParser {
     struct Solid {
       std::vector<Structs::Vector4> vertices;
       std::vector<uint16_t> indices;
-
+      Structs::Vector3 centerOfMass;
       int32_t boneIndex;
     };
 
@@ -40,7 +40,9 @@ namespace PhyParser {
 
     [[nodiscard]] static std::vector<Solid> parseMopp(const OffsetDataView& data);
 
-    [[nodiscard]] static Solid parseLedge(const Structs::Ledge& ledge, const OffsetDataView& data);
+    [[nodiscard]] static Solid parseLedge(
+      const Structs::Ledge& ledge, const Structs::Vector3& centerOfMass, const OffsetDataView& data
+    );
 
     [[nodiscard]] static uint16_t remapIndex(
       const Structs::Edge& edge, std::map<uint16_t, uint16_t>& remappedIndices, uint32_t& maxIndex


### PR DESCRIPTION
Really simple, all this does is expose `massCentre` to users by setting it in each `Solid` according to their respective compact surface headers.